### PR TITLE
Added an option to the ROmniture::Client#initialize method

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -25,9 +25,10 @@ Here's an example of initializing with a few configuration options.
       username, 
       shared_secret, 
       :san_jose, 
-      :log => false,    # Optionally turn off logging if it ticks you off
-      :wait_time => 1   # Amount of seconds to wait in between pinging 
-                        # Omniture's servers to see if a report is done processing (BEWARE OF TOKENS!)
+			:verify_mode	=> nil	# Optionaly change the ssl verify mode.
+      :log => false,    		# Optionally turn off logging if it ticks you off
+      :wait_time => 1   		# Amount of seconds to wait in between pinging 
+                        		# Omniture's servers to see if a report is done processing (BEWARE OF TOKENS!)
       )
     
 ## usage

--- a/README.markdown
+++ b/README.markdown
@@ -25,7 +25,7 @@ Here's an example of initializing with a few configuration options.
       username, 
       shared_secret, 
       :san_jose, 
-			:verify_mode	=> nil	# Optionaly change the ssl verify mode.
+      :verify_mode	=> nil	# Optionaly change the ssl verify mode.
       :log => false,    		# Optionally turn off logging if it ticks you off
       :wait_time => 1   		# Amount of seconds to wait in between pinging 
                         		# Omniture's servers to see if a report is done processing (BEWARE OF TOKENS!)

--- a/lib/romniture/client.rb
+++ b/lib/romniture/client.rb
@@ -20,6 +20,7 @@ module ROmniture
 
       @wait_time      = options[:wait_time] ? options[:wait_time] : DEFAULT_REPORT_WAIT_TIME
       @log            = options[:log] ? options[:log] : false
+      @use_ssl        = options[:user_ssl] ? options[:use_ssl] : false
       HTTPI.log       = false
     end
         
@@ -70,6 +71,9 @@ module ROmniture
       log(Logger::INFO, "Created new nonce: #{@password}")
       
       request = HTTPI::Request.new
+
+      request.use_ssl = @use_ssl
+
       request.url = @environment + "?method=#{method}"
       request.headers = request_headers
       request.body = data.to_json

--- a/lib/romniture/client.rb
+++ b/lib/romniture/client.rb
@@ -20,7 +20,7 @@ module ROmniture
 
       @wait_time      = options[:wait_time] ? options[:wait_time] : DEFAULT_REPORT_WAIT_TIME
       @log            = options[:log] ? options[:log] : false
-      @verify_mode        = options[:verify_mode] ? options[:verify_mode] : false
+      @verify_mode    = options[:verify_mode] ? options[:verify_mode] : false
       HTTPI.log       = false
     end
         

--- a/lib/romniture/client.rb
+++ b/lib/romniture/client.rb
@@ -20,7 +20,7 @@ module ROmniture
 
       @wait_time      = options[:wait_time] ? options[:wait_time] : DEFAULT_REPORT_WAIT_TIME
       @log            = options[:log] ? options[:log] : false
-      @use_ssl        = options[:user_ssl] ? options[:use_ssl] : false
+      @verify_mode        = options[:verify_mode] ? options[:verify_mode] : false
       HTTPI.log       = false
     end
         
@@ -72,7 +72,9 @@ module ROmniture
       
       request = HTTPI::Request.new
 
-      request.use_ssl = @use_ssl
+      if @verify_mode
+        request.auth.ssl.verify_mode = @verify_mode
+      end
 
       request.url = @environment + "?method=#{method}"
       request.headers = request_headers

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -14,6 +14,7 @@ class ClientTest < Test::Unit::TestCase
       @config["username"],
       @config["shared_secret"],
       @config["environment"],
+      :verify_mode => @config['verify_mode'],
       :wait_time => @config["wait_time"]
     )
   end


### PR DESCRIPTION
I added a :verify_mode to the Client initialize method. I also change the ROmniture::Client#send_request method to change the request.auth.ssl.verify_mode to what is set in the initialize method

I was getting an SSL_connect error like this:
**"SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed"**
By changing the request.auth.ssl.verify_method I was able to get the correct response
