### PR TITLE
Fix for: https://github.com/msukmanowsky/ROmniture/issues/2

### DIFF
--- a/lib/romniture/client.rb
+++ b/lib/romniture/client.rb
@@ -26,8 +26,15 @@ module ROmniture
         
     def request(method, parameters = {})
       response = send_request(method, parameters)
-      
-      JSON.parse(response.body)
+
+      begin
+        JSON.parse(response.body)
+      rescue JSON::ParserError => pe
+        response.body
+      rescue Exception => e
+        log(Logger::ERROR, "Error in request response:\n#{response.body}")
+        raise "Error in request response:\n#{response.body}"
+      end
     end
     
     def get_report(method, report_description)      

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -5,11 +5,11 @@ require 'yaml'
 require 'romniture'
 
 class ClientTest < Test::Unit::TestCase
-  
+
   def setup
     config = YAML::load(File.open("test/config.yml"))
     @config = config["omniture"]
-    
+
     @client = ROmniture::Client.new(
       @config["username"],
       @config["shared_secret"],
@@ -18,14 +18,14 @@ class ClientTest < Test::Unit::TestCase
       :wait_time => @config["wait_time"]
     )
   end
-  
+
   def test_simple_request
     response = @client.request('Company.GetReportSuites')
-    
+
     assert_instance_of Hash, response, "Returned object is not a hash."
     assert(response.has_key?("report_suites"), "Returned hash does not contain any report suites.")
   end
-  
+
   def test_report_request
     response = @client.get_report "Report.QueueOvertime", {
       "reportDescription" => {
@@ -35,11 +35,11 @@ class ClientTest < Test::Unit::TestCase
         "metrics" => [{"id" => "pageviews"}]
         }
       }
-    
+
     assert_instance_of Hash, response, "Returned object is not a hash."
     assert(response["report"].has_key?("data"), "Returned hash has no data!")
   end
-  
+
   def test_a_bad_request
     # Bad request, mixing commerce and traffic variables
     assert_raise(ROmniture::Exceptions::OmnitureReportException) do
@@ -54,5 +54,9 @@ class ClientTest < Test::Unit::TestCase
       })
     end
   end
-  
+
+  def test_return_response_body_on_parse_error
+    non_json_response = @client.request('Company.GetTokenCount')
+    assert_instance_of String, non_json_response, "Company.GetTokenCount returned #{non_json_response}."
+  end
 end


### PR DESCRIPTION
Added an exception catch for parse errors to dump out the body of the response in the case of non-valid JSON responses.
