### PR TITLE
Change metric name to an invalid name so that exception is raised

### DIFF
--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -42,14 +42,14 @@ class ClientTest < Test::Unit::TestCase
   end
 
   def test_a_bad_request
-    # Bad request, mixing commerce and traffic variables
+    # Bad request, with an invalid metric name
     assert_raise(ROmniture::Exceptions::OmnitureReportException) do
       response = @client.get_report("Report.QueueTrended", {
         "reportDescription" => {
           "reportSuiteID" => @config["report_suite_id"],
           "dateFrom" => "2011-01-01",
           "dateTo" => "2011-01-11",
-          "metrics" => [{"id" => "pageviews"}, {"id" => "event11"}],
+          "metrics" => [{"id" => "pageviews"}, {"id" => "badName"}],
           "elements" => [{"id" => "siteSection"}]
         }
       })


### PR DESCRIPTION
I just found your ROmniture library and was planning on using it for my project, so I started off by running the tests you provided with it.  One of the tests was failing because I was not getting an exception when commerce and traffic variables were mixed.  It seems that Omniture now allows this.

So, I modified the test to have some other behavior that would cause an exception - in this case, I just but in a bad element name.  This causes the exception to be properly raised and thus the test to properly fail.
