### PR TITLE
Add flatten_response capabilities to make working with the Omniture API Responses Easier

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,9 @@
 source "http://rubygems.org"
 
+#Ensure we dont request the 2.x lines of these dependencies, which in turn require Ruby 2, which we're not yet using.
+gem 'rack', '~>1.6'
+gem 'json', '~>1.8' 
+
 # Specify your gem's dependencies in romniture.gemspec
 gemspec
+

--- a/lib/romniture/client.rb
+++ b/lib/romniture/client.rb
@@ -5,7 +5,7 @@ module ROmniture
     DEFAULT_REPORT_WAIT_TIME = 0.25
     
     ENVIRONMENTS = {
-      :san_jose       => "https://api.omniture.com/admin/1.3/rest/",
+      :san_jose       => "https://api5.omniture.com/admin/1.3/rest/",
       :dallas         => "https://api2.omniture.com/admin/1.3/rest/",
       :london         => "https://api3.omniture.com/admin/1.3/rest/",
       :san_jose_beta  => "https://beta-api.omniture.com/admin/1.3/rest/",

--- a/lib/romniture/client.rb
+++ b/lib/romniture/client.rb
@@ -21,7 +21,7 @@ module ROmniture
       @wait_time      = options[:wait_time] ? options[:wait_time] : DEFAULT_REPORT_WAIT_TIME
       @log            = options[:log] ? options[:log] : false
       @verify_mode    = options[:verify_mode] ? options[:verify_mode] : false
-      HTTPI.log       = false
+      HTTPI.log       = true
     end
         
     def request(method, parameters = {})
@@ -151,7 +151,8 @@ module ROmniture
 
     def request_headers 
       {
-        "X-WSSE" => "UsernameToken Username=\"#{@username}\", PasswordDigest=\"#{@password}\", Nonce=\"#{@nonce}\", Created=\"#{@created}\""
+        "X-WSSE" => "UsernameToken Username=\"#{@username}\", PasswordDigest=\"#{@password}\", Nonce=\"#{@nonce}\", Created=\"#{@created}\"",
+        'Content-Type' => 'application/json'   #Added by ROB on 2013-08-22 because the Adobe Social API seems to require this be set
       }
     end
     

--- a/test/flatten_response_test.rb
+++ b/test/flatten_response_test.rb
@@ -1,0 +1,112 @@
+require 'test/unit'
+require 'yaml'
+$:.unshift File.expand_path('../../lib', __FILE__)
+require 'romniture'
+
+=begin 
+In order to properly run these tests, create a config.yml file
+with the following values filled in:
+
+omniture:
+  username: "username"
+  shared_secret: "shared_secret"
+  environment: :san_jose
+  verify_mode: :none
+  wait_time: 10
+  report_suite_id: "report_suite_id"
+
+expected_values:
+  march_1_2013_pageviews_for_chrome_25: 500
+  march_1_2013_pageviews_for_ie_10: 500
+  valid_page_name_to_find: "Home Page"
+  march_1_2013_pageviews_for_chrome_25_for_specific_page: 500
+  march_1_2013_visits_for_chrome_25: 500
+  march_1_2013_total_pageviews: 500
+  march_1_2013_total_visits: 500
+
+=end
+
+class ParseResponseTest < Test::Unit::TestCase
+
+  def setup
+    config = YAML::load(File.open("test/config.yml"))
+    @config = config["omniture"]
+    @expected_values = config["expected_values"]
+
+    @client = ROmniture::Client.new(
+      @config["username"],
+      @config["shared_secret"],
+      @config["environment"],
+      :verify_mode => @config['verify_mode'],
+      :wait_time => @config["wait_time"]
+    )
+
+    @request ={
+      "reportDescription" => {
+        "reportSuiteID" => @config["report_suite_id"],
+        "dateFrom" => "2013-03-01",
+        "dateTo" => "2013-03-01",
+        "dateGranularity" => "day",
+        "metrics" => [{"id" => "pageViews"}],
+        "elements" => [{"id" => "browser"}]
+    }}
+
+  end
+
+  def test_proper_value_parsed_from_basic_one_metric_one_element_trended_report
+    resp = @client.get_report "Report.QueueTrended", @request
+    flattened = @client.flatten_response(resp)
+    assert_equal @expected_values["march_1_2013_pageviews_for_chrome_25"], flattened.find{|e| e['browser'] == "Google Chrome 25.0" and e["datetime"] = "Fri.  1 Mar. 2013"}['pageViews']
+  end
+
+  def test_proper_value_parsed_from_single_day_in_trended_report_for_several_days
+    @request["reportDescription"]["dateTo"] = "2013-03-04"
+    resp = @client.get_report "Report.QueueTrended", @request
+    flattened = @client.flatten_response(resp)
+    assert_equal @expected_values["march_1_2013_pageviews_for_chrome_25"], flattened.find{|e| e['browser'] == "Google Chrome 25.0" and e["datetime"] = "Fri.  1 Mar. 2013"}['pageViews']
+    assert_equal 4, flattened.uniq{|e| e['datetime']}.count
+  end
+
+  def test_proper_value_parsed_with_filter_selected_in_element_request
+    @request["reportDescription"]["elements"] = [{"id" => "browser", "selected" => ["Microsoft Internet Explorer 10"]}]
+    resp = @client.get_report "Report.QueueTrended", @request
+    flattened = @client.flatten_response(resp)
+    assert_equal @expected_values["march_1_2013_pageviews_for_ie_10"], flattened[0]["pageViews"]
+    assert_equal 1, flattened.length
+  end
+
+  def test_proper_value_parsed_from_two_element_correlated_trended_report
+     @request["reportDescription"]["elements"] = [{"id" => "page"}, {"id" => "browser"}]
+     resp = @client.get_report "Report.QueueTrended", @request
+     flattened = @client.flatten_response(resp)
+     assert_equal @expected_values["march_1_2013_pageviews_for_chrome_25_for_specific_page"], flattened.find{|e| e['browser'] == "Google Chrome 25.0" and e['page'] == @expected_values["valid_page_name_to_find"] and e["datetime"] = "Fri.  1 Mar. 2013"}['pageViews']
+  end
+
+  def test_proper_value_parsed_from_two_metric_report
+    @request["reportDescription"]["metrics"] << {"id" => "visits"}
+    resp = @client.get_report "Report.QueueTrended", @request
+    flattened = @client.flatten_response(resp)
+    assert_equal @expected_values["march_1_2013_pageviews_for_chrome_25"], flattened.find{|e| e['browser'] == "Google Chrome 25.0" and e["datetime"] = "Fri.  1 Mar. 2013"}['pageViews']
+    assert_equal @expected_values["march_1_2013_visits_for_chrome_25"], flattened.find{|e| e['browser'] == "Google Chrome 25.0" and e["datetime"] = "Fri.  1 Mar. 2013"}['visits'] 
+  end
+
+  def test_proper_value_parsed_from_no_element_overtime_report
+    @request["reportDescription"]["elements"] = []
+    resp = @client.get_report "Report.QueueOvertime", @request
+    flattened = @client.flatten_response(resp)
+    assert_equal @expected_values["march_1_2013_total_pageviews"], flattened[0]["pageViews"]
+    assert_equal 1, flattened.length
+  end
+
+  def test_proper_value_parsed_from_no_element_two_metric_overtime_report
+    @request["reportDescription"]["elements"] = []
+    @request["reportDescription"]["metrics"] << {"id" => "visits"}
+    resp = @client.get_report "Report.QueueOvertime", @request
+    flattened = @client.flatten_response(resp)
+    assert_equal @expected_values["march_1_2013_total_pageviews"], flattened[0]["pageViews"]
+    assert_equal 1, flattened.length
+    assert_equal @expected_values["march_1_2013_total_visits"], flattened[0]["visits"]
+  end
+
+
+end


### PR DESCRIPTION
One of the more time-consuming parts of working with Omniture's API has been working with the hierarchical, deeply-nested responses that the API provides for Trended reports.  For example, if you request a report with two elements (say, 'browser' and 'page') plus the date, Omniture returns a tree-like response that may first have the browser, then all of the pages broken down underneath that, and then all of the dates broken down underneath that.  

This commit contains something I have found to be very helpful - it basically flattens/denormalizes the response so you always end up with just a simple array of hashes.  So for the example above you'd end up with something like the following:

```
[
  {browser: "Google Chrome 25.0",  page: "Home Page",  datetime: "Fri. 1 Mar. 2013", visits: 2000},
  {browser: "Internet Explorer 10", page: "Home Page", datetime: "Fri. 1 Mar. 2013", visits: 1442},
... etc...
```

To invoke this flattening capability,  just call it like this:

``` ruby
 resp = @client.get_report "Report.QueueOvertime", @request
 flattened = @client.flatten_response(resp)
```

I have included a set of Unit Tests for this functionality as well that confirm that it works with Trended reports for 1 or 2 elements, and for Overtime reports (with 0 elements)
